### PR TITLE
Complete StartCommandResult API documentation

### DIFF
--- a/docs/xml/Android.App/StartCommandResult.xml
+++ b/docs/xml/Android.App/StartCommandResult.xml
@@ -44,7 +44,7 @@
       </ReturnValue>
       <MemberValue>15</MemberValue>
       <Docs>
-        <summary ToolPath="TrimmedButTooLong" tool="FirstSentenceInJavadocToMdoc">To be added.</summary>
+        <summary ToolPath="TrimmedButTooLong" tool="FirstSentenceInJavadocToMdoc">Masks the bits that describe how to continue the service if its process is killed.</summary>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -71,7 +71,7 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary ToolPath="Untrimmed" tool="FirstSentenceInJavadocToMdoc">To be added.</summary>
+        <summary ToolPath="Untrimmed" tool="FirstSentenceInJavadocToMdoc">Does not recreate the service after its process is killed unless there are pending intents to deliver.</summary>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -98,7 +98,7 @@
       </ReturnValue>
       <MemberValue>3</MemberValue>
       <Docs>
-        <summary ToolPath="TrimmedButTooLong" tool="FirstSentenceInJavadocToMdoc">To be added.</summary>
+        <summary ToolPath="TrimmedButTooLong" tool="FirstSentenceInJavadocToMdoc">Recreates the service after its process is killed and redelivers the last intent.</summary>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -156,7 +156,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary ToolPath="TrimmedButTooLong" tool="FirstSentenceInJavadocToMdoc">To be added.</summary>
+        <summary ToolPath="TrimmedButTooLong" tool="FirstSentenceInJavadocToMdoc">Provides compatibility with <see cref="F:Android.App.StartCommandResult.Sticky" /> without guaranteeing that <see cref="M:Android.App.Service.OnStartCommand(Android.Content.Intent,Android.App.StartCommandFlags,System.Int32)" /> is called again after the service is killed.</summary>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>


### PR DESCRIPTION
`StartCommandResult` documents only `Sticky`, leaving four service continuation modes with placeholder summaries. This completes those summaries with concise descriptions faithful to the corresponding Android `Service` constants while preserving the existing mdoc structure and attribution remarks.

Fixes dotnet/android#7446