### PR TITLE
Fill Android.Accounts documentation placeholders

### DIFF
--- a/docs/xml/Android.Accounts/AbstractAccountAuthenticator.xml
+++ b/docs/xml/Android.Accounts/AbstractAccountAuthenticator.xml
@@ -124,7 +124,7 @@
         <Parameter Name="context" Type="Android.Content.Context" />
       </Parameters>
       <Docs>
-        <param name="context">To be added.</param>
+        <param name="context">The Android context used by the authenticator service.</param>
         <summary>
         </summary>
         <remarks>
@@ -865,8 +865,8 @@
         <ReturnType>Java.Interop.JniPeerMembers</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
+        <summary>This API supports the Mono for Android infrastructure and is not intended to be used directly from your code.</summary>
+        <value>A <see cref="T:Java.Interop.JniPeerMembers" /> instance that provides access to JNI peer-member information for this type.</value>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>

--- a/docs/xml/Android.Accounts/Account+InterfaceConsts.xml
+++ b/docs/xml/Android.Accounts/Account+InterfaceConsts.xml
@@ -12,7 +12,7 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
+    <summary>Constants re-exported from <c>android.os.Parcelable</c> for use with <see cref="T:Android.Accounts.Account" />.</summary>
     <remarks>
       <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
     </remarks>

--- a/docs/xml/Android.Accounts/Account.xml
+++ b/docs/xml/Android.Accounts/Account.xml
@@ -74,7 +74,7 @@
         <Parameter Name="in" Type="Android.OS.Parcel" />
       </Parameters>
       <Docs>
-        <param name="in">To be added.</param>
+        <param name="in">The parcel from which to read the account data.</param>
         <summary>
         </summary>
         <remarks>
@@ -128,8 +128,8 @@
         <Parameter Name="type" Type="System.String" />
       </Parameters>
       <Docs>
-        <param name="name">To be added.</param>
-        <param name="type">To be added.</param>
+        <param name="name">The account name. This value must not be empty.</param>
+        <param name="type">The authenticator type for the account. This value must not be empty.</param>
         <summary>
         </summary>
         <remarks>
@@ -160,7 +160,7 @@
       <Docs>
         <summary>
         </summary>
-        <value>To be added.</value>
+        <value>A parcelable creator that creates <see cref="T:Android.Accounts.Account" /> instances from parcels.</value>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -193,7 +193,7 @@
       <Docs>
         <summary>Describe the kinds of special objects contained in this Parcelable's
  marshalled representation.</summary>
-        <returns>To be added.</returns>
+        <returns>Always <c>0</c> because this parcelable contains no file descriptors.</returns>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -231,8 +231,8 @@
         <ReturnType>Java.Interop.JniPeerMembers</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
+        <summary>This API supports the Mono for Android infrastructure and is not intended to be used directly from your code.</summary>
+        <value>A <see cref="T:Java.Interop.JniPeerMembers" /> instance that provides access to JNI peer-member information for this type.</value>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -260,7 +260,7 @@
       <Docs>
         <summary>
         </summary>
-        <value>To be added.</value>
+        <value>The name that identifies the account within its authenticator type.</value>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -355,7 +355,7 @@
       <Docs>
         <summary>
         </summary>
-        <value>To be added.</value>
+        <value>The authenticator type that identifies the service managing the account.</value>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>

--- a/docs/xml/Android.Accounts/AccountAuthenticatorActivity.xml
+++ b/docs/xml/Android.Accounts/AccountAuthenticatorActivity.xml
@@ -132,8 +132,8 @@
         <ReturnType>Java.Interop.JniPeerMembers</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
+        <summary>This API supports the Mono for Android infrastructure and is not intended to be used directly from your code.</summary>
+        <value>A <see cref="T:Java.Interop.JniPeerMembers" /> instance that provides access to JNI peer-member information for this type.</value>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>

--- a/docs/xml/Android.Accounts/AccountAuthenticatorResponse+InterfaceConsts.xml
+++ b/docs/xml/Android.Accounts/AccountAuthenticatorResponse+InterfaceConsts.xml
@@ -12,7 +12,7 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
+    <summary>Constants re-exported from <c>android.os.Parcelable</c> for use with <see cref="T:Android.Accounts.AccountAuthenticatorResponse" />.</summary>
     <remarks>
       <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
     </remarks>

--- a/docs/xml/Android.Accounts/AccountAuthenticatorResponse.xml
+++ b/docs/xml/Android.Accounts/AccountAuthenticatorResponse.xml
@@ -72,7 +72,7 @@
         <Parameter Name="parcel" Type="Android.OS.Parcel" />
       </Parameters>
       <Docs>
-        <param name="parcel">To be added.</param>
+        <param name="parcel">The parcel from which to reconstruct the response object.</param>
         <summary>
         </summary>
         <remarks>
@@ -126,7 +126,7 @@
       <Docs>
         <summary>
         </summary>
-        <value>To be added.</value>
+        <value>A parcelable creator that creates <see cref="T:Android.Accounts.AccountAuthenticatorResponse" /> instances from parcels.</value>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -159,7 +159,7 @@
       <Docs>
         <summary>Describe the kinds of special objects contained in this Parcelable's
  marshalled representation.</summary>
-        <returns>To be added.</returns>
+        <returns>Always <c>0</c> because this parcelable contains no file descriptors.</returns>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -197,8 +197,8 @@
         <ReturnType>Java.Interop.JniPeerMembers</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
+        <summary>This API supports the Mono for Android infrastructure and is not intended to be used directly from your code.</summary>
+        <value>A <see cref="T:Java.Interop.JniPeerMembers" /> instance that provides access to JNI peer-member information for this type.</value>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -235,8 +235,8 @@
         <Parameter Name="errorMessage" Type="System.String" />
       </Parameters>
       <Docs>
-        <param name="errorCode">To be added.</param>
-        <param name="errorMessage">To be added.</param>
+        <param name="errorCode">An error code corresponding to one of the <c>AccountManager.ERROR_CODE_*</c> constants.</param>
+        <param name="errorMessage">A human-readable description of the error.</param>
         <summary>
         </summary>
         <remarks>
@@ -297,7 +297,7 @@
         <Parameter Name="result" Type="Android.OS.Bundle" />
       </Parameters>
       <Docs>
-        <param name="result">To be added.</param>
+        <param name="result">A bundle containing the result data to send to the account manager.</param>
         <summary>
         </summary>
         <remarks>

--- a/docs/xml/Android.Accounts/AccountManager.xml
+++ b/docs/xml/Android.Accounts/AccountManager.xml
@@ -166,7 +166,7 @@
         <ReturnType>System.EventHandler&lt;Android.Accounts.AccountsUpdateEventArgs&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Occurs when the account manager starts and whenever the set of accounts changes.</summary>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -1358,9 +1358,9 @@
         <Parameter Name="context" Type="Android.Content.Context" />
       </Parameters>
       <Docs>
-        <param name="context">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
+        <param name="context">The context to use when necessary. Its lifetime should be commensurate with any registered listeners.</param>
+        <summary>Gets an account manager instance associated with a context.</summary>
+        <returns>An account manager instance associated with <paramref name="context" />.</returns>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -2483,7 +2483,7 @@
         <Parameter Name="key" Type="System.String" />
       </Parameters>
       <Docs>
-        <param name="key">To be added.</param>
+        <param name="key">The key of the user data entry to retrieve.</param>
         <param name="account">The account to query for user data</param>
         <summary>Gets the user data named by "key" associated with the account.</summary>
         <returns>The user data, null if the account, key doesn't exist, or the user is locked</returns>
@@ -2714,8 +2714,8 @@
         <ReturnType>Java.Interop.JniPeerMembers</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
+        <summary>This API supports the Mono for Android infrastructure and is not intended to be used directly from your code.</summary>
+        <value>A <see cref="T:Java.Interop.JniPeerMembers" /> instance that provides access to JNI peer-member information for this type.</value>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>

--- a/docs/xml/Android.Accounts/AccountVisibility.xml
+++ b/docs/xml/Android.Accounts/AccountVisibility.xml
@@ -11,7 +11,7 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
+    <summary>Specifies an account's visibility to an application.</summary>
     <remarks>
       <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
     </remarks>
@@ -42,7 +42,7 @@
       </ReturnValue>
       <MemberValue>3</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>The account is not visible to the application, and only the authenticator can grant visibility.</summary>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -73,7 +73,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>The account visibility has not been set, so the default visibility is used.</summary>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -104,7 +104,7 @@
       </ReturnValue>
       <MemberValue>4</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>The account is not visible to the application, but the user can reveal it.</summary>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -135,7 +135,7 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>The account is visible to the application, but the user can revoke visibility.</summary>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -166,7 +166,7 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>The account is always visible to the application, and only the authenticator can revoke visibility.</summary>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>

--- a/docs/xml/Android.Accounts/AccountsException.xml
+++ b/docs/xml/Android.Accounts/AccountsException.xml
@@ -22,7 +22,7 @@
     </Attribute>
   </Attributes>
   <Docs since="5">
-    <summary>To be added.</summary>
+    <summary>The base class for exceptions thrown by the Android accounts service.</summary>
     <remarks>
       <para>
         <format type="text/html">
@@ -78,7 +78,7 @@
         <Parameter Name="cause" Type="Java.Lang.Throwable" />
       </Parameters>
       <Docs>
-        <param name="cause">To be added.</param>
+        <param name="cause">The cause of this exception.</param>
         <summary>
         </summary>
         <remarks>
@@ -107,7 +107,7 @@
         <Parameter Name="message" Type="System.String" />
       </Parameters>
       <Docs>
-        <param name="message">To be added.</param>
+        <param name="message">A human-readable detail message.</param>
         <summary>
         </summary>
         <remarks>
@@ -160,8 +160,8 @@
         <Parameter Name="cause" Type="Java.Lang.Throwable" />
       </Parameters>
       <Docs>
-        <param name="message">To be added.</param>
-        <param name="cause">To be added.</param>
+        <param name="message">A human-readable detail message.</param>
+        <param name="cause">The cause of this exception.</param>
         <summary>
         </summary>
         <remarks>
@@ -194,8 +194,8 @@
         <ReturnType>Java.Interop.JniPeerMembers</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
+        <summary>This API supports the Mono for Android infrastructure and is not intended to be used directly from your code.</summary>
+        <value>A <see cref="T:Java.Interop.JniPeerMembers" /> instance that provides access to JNI peer-member information for this type.</value>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>

--- a/docs/xml/Android.Accounts/AccountsUpdateEventArgs.xml
+++ b/docs/xml/Android.Accounts/AccountsUpdateEventArgs.xml
@@ -39,8 +39,8 @@
         </Parameter>
       </Parameters>
       <Docs>
-        <param name="accounts">To be added.</param>
-        <summary>To be added.</summary>
+        <param name="accounts">The current set of accounts visible to the caller.</param>
+        <summary>Initializes a new instance of the <see cref="T:Android.Accounts.AccountsUpdateEventArgs" /> class.</summary>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -66,8 +66,8 @@
         <ReturnType>Android.Accounts.Account[]</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
+        <summary>Gets the current set of accounts visible to the caller.</summary>
+        <value>The current set of accounts visible to the caller.</value>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>

--- a/docs/xml/Android.Accounts/AuthenticatorDescription+InterfaceConsts.xml
+++ b/docs/xml/Android.Accounts/AuthenticatorDescription+InterfaceConsts.xml
@@ -12,7 +12,7 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
+    <summary>Constants re-exported from <c>android.os.Parcelable</c> for use with <see cref="T:Android.Accounts.AuthenticatorDescription" />.</summary>
     <remarks>
       <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
     </remarks>

--- a/docs/xml/Android.Accounts/AuthenticatorDescription.xml
+++ b/docs/xml/Android.Accounts/AuthenticatorDescription.xml
@@ -100,12 +100,12 @@
         <Parameter Name="prefId" Type="System.Int32" />
       </Parameters>
       <Docs>
-        <param name="type">To be added.</param>
-        <param name="packageName">To be added.</param>
-        <param name="labelId">To be added.</param>
-        <param name="iconId">To be added.</param>
-        <param name="smallIconId">To be added.</param>
-        <param name="prefId">To be added.</param>
+        <param name="type">The string that uniquely identifies the authenticator.</param>
+        <param name="packageName">The package name used to look up the authenticator's resources.</param>
+        <param name="labelId">The resource ID of a label suitable for displaying the authenticator.</param>
+        <param name="iconId">The resource ID of an icon for the authenticator.</param>
+        <param name="smallIconId">The resource ID of a smaller icon for the authenticator.</param>
+        <param name="prefId">The resource ID of a preference hierarchy to add to the account settings page.</param>
         <summary>A constructor for a full AuthenticatorDescription</summary>
         <remarks>
           <para>
@@ -148,13 +148,13 @@
         <Parameter Name="customTokens" Type="System.Boolean" />
       </Parameters>
       <Docs>
-        <param name="type">To be added.</param>
-        <param name="packageName">To be added.</param>
-        <param name="labelId">To be added.</param>
-        <param name="iconId">To be added.</param>
-        <param name="smallIconId">To be added.</param>
-        <param name="prefId">To be added.</param>
-        <param name="customTokens">To be added.</param>
+        <param name="type">The string that uniquely identifies the authenticator.</param>
+        <param name="packageName">The package name used to look up the authenticator's resources.</param>
+        <param name="labelId">The resource ID of a label suitable for displaying the authenticator.</param>
+        <param name="iconId">The resource ID of an icon for the authenticator.</param>
+        <param name="smallIconId">The resource ID of a smaller icon for the authenticator.</param>
+        <param name="prefId">The resource ID of a preference hierarchy to add to the account settings page.</param>
+        <param name="customTokens"><see langword="true" /> if the authenticator handles its own token caching and permission screen; otherwise, <see langword="false" />.</param>
         <summary>A constructor for a full AuthenticatorDescription</summary>
         <remarks>
           <para>A constructor for a full AuthenticatorDescription</para>
@@ -194,7 +194,7 @@
       <Docs>
         <summary>A resource id for a hierarchy of PreferenceScreen to be added to the settings page for the
             account.</summary>
-        <value>To be added.</value>
+        <value>The resource ID of the preference hierarchy for the account settings page.</value>
         <remarks>
           <para>A resource id for a hierarchy of PreferenceScreen to be added to the settings page for the
             account. See <c>AbstractAccountAuthenticator</c> for an example.</para>
@@ -233,7 +233,7 @@
       </ReturnValue>
       <Docs>
         <summary>Used to create the object from a parcel.</summary>
-        <value>To be added.</value>
+        <value>A parcelable creator for <see cref="T:Android.Accounts.AuthenticatorDescription" /> instances.</value>
         <remarks>
           <para>
             <format type="text/html">
@@ -270,7 +270,7 @@
       </ReturnValue>
       <Docs>
         <summary>Authenticator handles its own token caching and permission screen</summary>
-        <value>To be added.</value>
+        <value><see langword="true" /> if the authenticator handles its own token caching and permission screen; otherwise, <see langword="false" />.</value>
         <remarks>
           <para>Authenticator handles its own token caching and permission screen</para>
           <para>
@@ -313,7 +313,7 @@
       <Docs>
         <summary>Describe the kinds of special objects contained in this Parcelable's
  marshalled representation.</summary>
-        <returns>To be added.</returns>
+        <returns>Always <c>0</c> because this parcelable contains no file descriptors.</returns>
         <remarks>
           <para>
             <format type="text/html">
@@ -350,7 +350,7 @@
       </ReturnValue>
       <Docs>
         <summary>A resource id of a icon for the authenticator</summary>
-        <value>To be added.</value>
+        <value>The resource ID of an icon for the authenticator.</value>
         <remarks>
           <para>A resource id of a icon for the authenticator</para>
           <para>
@@ -398,8 +398,8 @@
         <ReturnType>Java.Interop.JniPeerMembers</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
+        <summary>This API supports the Mono for Android infrastructure and is not intended to be used directly from your code.</summary>
+        <value>A <see cref="T:Java.Interop.JniPeerMembers" /> instance that provides access to JNI peer-member information for this type.</value>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -426,7 +426,7 @@
       </ReturnValue>
       <Docs>
         <summary>A resource id of a label for the authenticator that is suitable for displaying</summary>
-        <value>To be added.</value>
+        <value>The resource ID of a label suitable for displaying the authenticator.</value>
         <remarks>
           <para>A resource id of a label for the authenticator that is suitable for displaying</para>
           <para>
@@ -466,10 +466,10 @@
         <Parameter Name="type" Type="System.String" />
       </Parameters>
       <Docs>
-        <param name="type">To be added.</param>
+        <param name="type">The string that uniquely identifies the authenticator.</param>
         <summary>A factory method for creating an AuthenticatorDescription that can be used as a key
             to identify the authenticator by its type.</summary>
-        <returns>To be added.</returns>
+        <returns>An authenticator description that can be used as a key for the specified authenticator type.</returns>
         <remarks>
           <para>A factory method for creating an AuthenticatorDescription that can be used as a key
             to identify the authenticator by its type.</para>
@@ -508,7 +508,7 @@
       </ReturnValue>
       <Docs>
         <summary>The package name that can be used to lookup the resources from above.</summary>
-        <value>To be added.</value>
+        <value>The package name used to look up the authenticator's resources.</value>
         <remarks>
           <para>The package name that can be used to lookup the resources from above.</para>
           <para>
@@ -546,7 +546,7 @@
       </ReturnValue>
       <Docs>
         <summary>A resource id of a smaller icon for the authenticator</summary>
-        <value>To be added.</value>
+        <value>The resource ID of a smaller icon for the authenticator.</value>
         <remarks>
           <para>A resource id of a smaller icon for the authenticator</para>
           <para>
@@ -650,7 +650,7 @@
       </ReturnValue>
       <Docs>
         <summary>The string that uniquely identifies an authenticator</summary>
-        <value>To be added.</value>
+        <value>The string that uniquely identifies the authenticator.</value>
         <remarks>
           <para>The string that uniquely identifies an authenticator</para>
           <para>

--- a/docs/xml/Android.Accounts/AuthenticatorException.xml
+++ b/docs/xml/Android.Accounts/AuthenticatorException.xml
@@ -22,7 +22,7 @@
     </Attribute>
   </Attributes>
   <Docs since="5">
-    <summary>To be added.</summary>
+    <summary>The exception thrown when communication with an authenticator fails or the authenticator returns an invalid response.</summary>
     <remarks>
       <para>
         <format type="text/html">
@@ -78,7 +78,7 @@
         <Parameter Name="cause" Type="Java.Lang.Throwable" />
       </Parameters>
       <Docs>
-        <param name="cause">To be added.</param>
+        <param name="cause">The cause of this exception.</param>
         <summary>
         </summary>
         <remarks>
@@ -107,7 +107,7 @@
         <Parameter Name="message" Type="System.String" />
       </Parameters>
       <Docs>
-        <param name="message">To be added.</param>
+        <param name="message">A human-readable detail message.</param>
         <summary>
         </summary>
         <remarks>
@@ -160,8 +160,8 @@
         <Parameter Name="cause" Type="Java.Lang.Throwable" />
       </Parameters>
       <Docs>
-        <param name="message">To be added.</param>
-        <param name="cause">To be added.</param>
+        <param name="message">A human-readable detail message.</param>
+        <param name="cause">The cause of this exception.</param>
         <summary>
         </summary>
         <remarks>
@@ -194,8 +194,8 @@
         <ReturnType>Java.Interop.JniPeerMembers</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
+        <summary>This API supports the Mono for Android infrastructure and is not intended to be used directly from your code.</summary>
+        <value>A <see cref="T:Java.Interop.JniPeerMembers" /> instance that provides access to JNI peer-member information for this type.</value>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>

--- a/docs/xml/Android.Accounts/ErrorCode.xml
+++ b/docs/xml/Android.Accounts/ErrorCode.xml
@@ -38,7 +38,7 @@
       </ReturnValue>
       <MemberValue>7</MemberValue>
       <Docs>
-        <summary ToolPath="Untrimmed" tool="FirstSentenceInJavadocToMdoc">To be added.</summary>
+        <summary ToolPath="Untrimmed" tool="FirstSentenceInJavadocToMdoc">The request contains invalid arguments.</summary>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -65,7 +65,7 @@
       </ReturnValue>
       <MemberValue>8</MemberValue>
       <Docs>
-        <summary ToolPath="Untrimmed" tool="FirstSentenceInJavadocToMdoc">To be added.</summary>
+        <summary ToolPath="Untrimmed" tool="FirstSentenceInJavadocToMdoc">The request is invalid.</summary>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -92,7 +92,7 @@
       </ReturnValue>
       <MemberValue>4</MemberValue>
       <Docs>
-        <summary ToolPath="Untrimmed" tool="FirstSentenceInJavadocToMdoc">To be added.</summary>
+        <summary ToolPath="Untrimmed" tool="FirstSentenceInJavadocToMdoc">The request was canceled.</summary>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -119,7 +119,7 @@
       </ReturnValue>
       <MemberValue>9</MemberValue>
       <Docs>
-        <summary ToolPath="Untrimmed" tool="FirstSentenceInJavadocToMdoc">To be added.</summary>
+        <summary ToolPath="Untrimmed" tool="FirstSentenceInJavadocToMdoc">The credentials were rejected.</summary>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -146,7 +146,7 @@
       </ReturnValue>
       <MemberValue>5</MemberValue>
       <Docs>
-        <summary ToolPath="Untrimmed" tool="FirstSentenceInJavadocToMdoc">To be added.</summary>
+        <summary ToolPath="Untrimmed" tool="FirstSentenceInJavadocToMdoc">The authenticator returned an invalid response.</summary>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -173,7 +173,7 @@
       </ReturnValue>
       <MemberValue>3</MemberValue>
       <Docs>
-        <summary ToolPath="Untrimmed" tool="FirstSentenceInJavadocToMdoc">To be added.</summary>
+        <summary ToolPath="Untrimmed" tool="FirstSentenceInJavadocToMdoc">A network error prevented the request from completing.</summary>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -200,7 +200,7 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary ToolPath="Untrimmed" tool="FirstSentenceInJavadocToMdoc">To be added.</summary>
+        <summary ToolPath="Untrimmed" tool="FirstSentenceInJavadocToMdoc">A remote exception occurred in the account management service.</summary>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -227,7 +227,7 @@
       </ReturnValue>
       <MemberValue>6</MemberValue>
       <Docs>
-        <summary ToolPath="Untrimmed" tool="FirstSentenceInJavadocToMdoc">To be added.</summary>
+        <summary ToolPath="Untrimmed" tool="FirstSentenceInJavadocToMdoc">The authenticator does not support the requested operation.</summary>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>

--- a/docs/xml/Android.Accounts/IAccountManagerCallback.xml
+++ b/docs/xml/Android.Accounts/IAccountManagerCallback.xml
@@ -29,7 +29,7 @@
     </Attribute>
   </Attributes>
   <Docs since="5">
-    <summary>To be added.</summary>
+    <summary>A callback interface for receiving the result of an asynchronous <see cref="T:Android.Accounts.AccountManager" /> operation.</summary>
     <remarks>
       <para>
         <format type="text/html">
@@ -63,8 +63,8 @@
         <Parameter Name="future" Type="Android.Accounts.IAccountManagerFuture" />
       </Parameters>
       <Docs>
-        <param name="future">To be added.</param>
-        <summary>To be added.</summary>
+        <param name="future">The future representing the completed operation. Call <c>GetResult()</c> to retrieve the result or exception.</param>
+        <summary>Called when the asynchronous account manager operation completes.</summary>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>

--- a/docs/xml/Android.Accounts/IAccountManagerFuture.xml
+++ b/docs/xml/Android.Accounts/IAccountManagerFuture.xml
@@ -195,7 +195,7 @@
       <Docs>
         <summary>Returns <c>true</c> if this task was cancelled before it completed
  normally.</summary>
-        <value>To be added.</value>
+        <value><see langword="true" /> if the task was canceled before normal completion; otherwise, <see langword="false" />.</value>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -223,7 +223,7 @@
       </ReturnValue>
       <Docs>
         <summary>Returns <c>true</c> if this task completed.</summary>
-        <value>To be added.</value>
+        <value><see langword="true" /> if the task completed normally, by exception, or by cancellation; otherwise, <see langword="false" />.</value>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>
@@ -255,7 +255,7 @@
       </ReturnValue>
       <Docs>
         <summary>Accessor for the future result the <see cref="T:Android.Accounts.IAccountManagerFuture" /> represents.</summary>
-        <value>To be added.</value>
+        <value>The operation result. Accessing this value blocks until the result is available.</value>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>

--- a/docs/xml/Android.Accounts/IAccountManagerFutureExtensions.xml
+++ b/docs/xml/Android.Accounts/IAccountManagerFutureExtensions.xml
@@ -12,7 +12,7 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
+    <summary>Extension methods for <see cref="T:Android.Accounts.IAccountManagerFuture" />.</summary>
     <remarks>
       <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
     </remarks>
@@ -50,11 +50,11 @@
         </Parameter>
       </Parameters>
       <Docs>
-        <param name="self">To be added.</param>
-        <param name="timeout">To be added.</param>
-        <param name="unit">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
+        <param name="self">The <see cref="T:Android.Accounts.IAccountManagerFuture" /> whose result to retrieve.</param>
+        <param name="timeout">The maximum time to wait, in units specified by <paramref name="unit" />.</param>
+        <param name="unit">The time unit for <paramref name="timeout" />.</param>
+        <summary>Asynchronously retrieves the future result, waiting up to the specified timeout.</summary>
+        <returns>A task that yields the future result when the operation completes.</returns>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>

--- a/docs/xml/Android.Accounts/NetworkErrorException.xml
+++ b/docs/xml/Android.Accounts/NetworkErrorException.xml
@@ -22,7 +22,7 @@
     </Attribute>
   </Attributes>
   <Docs since="5">
-    <summary>To be added.</summary>
+    <summary>The exception thrown when a network error prevents an authenticator from completing a request.</summary>
     <remarks>
       <para>
         <format type="text/html">
@@ -78,7 +78,7 @@
         <Parameter Name="cause" Type="Java.Lang.Throwable" />
       </Parameters>
       <Docs>
-        <param name="cause">To be added.</param>
+        <param name="cause">The cause of this exception.</param>
         <summary>
         </summary>
         <remarks>
@@ -107,7 +107,7 @@
         <Parameter Name="message" Type="System.String" />
       </Parameters>
       <Docs>
-        <param name="message">To be added.</param>
+        <param name="message">A human-readable detail message.</param>
         <summary>
         </summary>
         <remarks>
@@ -160,8 +160,8 @@
         <Parameter Name="cause" Type="Java.Lang.Throwable" />
       </Parameters>
       <Docs>
-        <param name="message">To be added.</param>
-        <param name="cause">To be added.</param>
+        <param name="message">A human-readable detail message.</param>
+        <param name="cause">The cause of this exception.</param>
         <summary>
         </summary>
         <remarks>
@@ -194,8 +194,8 @@
         <ReturnType>Java.Interop.JniPeerMembers</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
+        <summary>This API supports the Mono for Android infrastructure and is not intended to be used directly from your code.</summary>
+        <value>A <see cref="T:Java.Interop.JniPeerMembers" /> instance that provides access to JNI peer-member information for this type.</value>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>

--- a/docs/xml/Android.Accounts/OperationCanceledException.xml
+++ b/docs/xml/Android.Accounts/OperationCanceledException.xml
@@ -22,7 +22,7 @@
     </Attribute>
   </Attributes>
   <Docs since="5">
-    <summary>To be added.</summary>
+    <summary>The exception thrown when an account manager operation is canceled before it completes.</summary>
     <remarks>
       <para>
         <format type="text/html">
@@ -78,7 +78,7 @@
         <Parameter Name="cause" Type="Java.Lang.Throwable" />
       </Parameters>
       <Docs>
-        <param name="cause">To be added.</param>
+        <param name="cause">The cause of this exception.</param>
         <summary>
         </summary>
         <remarks>
@@ -107,7 +107,7 @@
         <Parameter Name="message" Type="System.String" />
       </Parameters>
       <Docs>
-        <param name="message">To be added.</param>
+        <param name="message">A human-readable detail message.</param>
         <summary>
         </summary>
         <remarks>
@@ -160,8 +160,8 @@
         <Parameter Name="cause" Type="Java.Lang.Throwable" />
       </Parameters>
       <Docs>
-        <param name="message">To be added.</param>
-        <param name="cause">To be added.</param>
+        <param name="message">A human-readable detail message.</param>
+        <param name="cause">The cause of this exception.</param>
         <summary>
         </summary>
         <remarks>
@@ -194,8 +194,8 @@
         <ReturnType>Java.Interop.JniPeerMembers</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
+        <summary>This API supports the Mono for Android infrastructure and is not intended to be used directly from your code.</summary>
+        <value>A <see cref="T:Java.Interop.JniPeerMembers" /> instance that provides access to JNI peer-member information for this type.</value>
         <remarks>
           <para>Portions of this page are modifications based on work created and shared by the <format type="text/html"><a href="https://developers.google.com/terms/site-policies" title="Android Open Source Project">Android Open Source Project</a></format> and used according to terms described in the <format type="text/html"><a href="https://creativecommons.org/licenses/by/2.5/" title="Creative Commons 2.5 Attribution License">Creative Commons 2.5 Attribution License.</a></format></para>
         </remarks>


### PR DESCRIPTION
The `Android.Accounts` API reference contained 86 placeholder entries, leaving important account-management types and members undocumented.

This replaces every `To be added.` entry in the namespace with descriptions grounded in the official Android reference and AOSP sources. It also applies established .NET binding conventions to generated surfaces such as `JniPeerMembers`, `InterfaceConsts`, event arguments, and async extensions.

Highlights:
- Documents account visibility and error-code values.
- Fills parameters, return values, properties, callbacks, futures, and exception descriptions.
- Removes all remaining placeholders from `docs/xml/Android.Accounts`.